### PR TITLE
Internal.CloseHandle: ReleaseHandle() should not check close(2) return value

### DIFF
--- a/IoUring/Internal/CloseHandle.cs
+++ b/IoUring/Internal/CloseHandle.cs
@@ -14,7 +14,12 @@ namespace IoUring.Internal
 
         public void SetHandle(int fd) => SetHandle((IntPtr)fd);
 
-        protected override bool ReleaseHandle() => close(handle.ToInt32()) == 0;
+        protected override bool ReleaseHandle()
+        {
+            // close(2) on Linux should not be checked other than for diagnostic purposes
+            close(handle.ToInt32());
+            return true;
+        }
 
         public override bool IsInvalid => handle.ToInt32() < 0;
     }


### PR DESCRIPTION
According to the manual page for close(2), on Linux, irregardless of
the error returned by the system call, the file descriptor will always
be closed.  Checking if the syscall failed shouldn't affect program
behavior unless it's for diagnostic or remedial purposes (and there
isn't much to be done when we're talking about socket file descriptors
here).