### PR TITLE
Transport: Create new sockets with SOCK_CLOEXEC

### DIFF
--- a/src/IoUring.Transport/LinuxSocket.cs
+++ b/src/IoUring.Transport/LinuxSocket.cs
@@ -40,7 +40,7 @@ namespace IoUring.Transport
         {
             sockaddr_storage addr;
             socklen_t len = SizeOf.sockaddr_storage;
-            var rv = accept4(_fd, (sockaddr*)&addr, &len, SOCK_NONBLOCK);
+            var rv = accept4(_fd, (sockaddr*)&addr, &len, SOCK_NONBLOCK | SOCK_CLOEXEC);
             if (rv < 0)
             {
                 var err = errno;

--- a/src/IoUring.Transport/TransportThread.cs
+++ b/src/IoUring.Transport/TransportThread.cs
@@ -54,7 +54,7 @@ namespace IoUring.Transport
         public void Bind()
         {
             var domain = _endPoint.AddressFamily == AddressFamily.InterNetwork ? AF_INET : AF_INET6;
-            LinuxSocket s = socket(domain, SOCK_STREAM | SOCK_NONBLOCK, IPPROTO_TCP);
+            LinuxSocket s = socket(domain, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, IPPROTO_TCP);
             s.SetOption(SOL_SOCKET, SO_REUSEADDR, 1);
             s.SetOption(SOL_SOCKET, SO_REUSEPORT, 1);
             s.Bind(_endPoint);


### PR DESCRIPTION
Most file descriptors in the runtime end up being created with the O_CLOEXEC option, so ensure that all sockets in this transport also do that, as we don't need to share these file descriptors between processes.