### PR TITLE
Don't Submit and Flush on behalf of the user when sq is full

### DIFF
--- a/src/IoUring/Ring.Submission.cs
+++ b/src/IoUring/Ring.Submission.cs
@@ -702,20 +702,6 @@ namespace IoUring
         public uint Flush(uint toFlush, uint minComplete = 0)
             => _sq.Flush(_ringFd.DangerousGetHandle().ToInt32(), SubmissionPollingEnabled, toFlush, minComplete);
 
-        private bool NextSubmissionQueueEntry(out io_uring_sqe* sqe)
-        {
-            sqe = _sq.NextSubmissionQueueEntry();
-            if (sqe == NULL)
-            {
-                if (Flush(Submit()) > 0)
-                {
-                    // Flushed one more item, retry to get an entry
-                    sqe = _sq.NextSubmissionQueueEntry();
-                    if (sqe == NULL) return false;
-                }
-            }
-
-            return true;
-        }
+        private bool NextSubmissionQueueEntry(out io_uring_sqe* sqe) => (sqe = _sq.NextSubmissionQueueEntry()) != NULL;
     }
 }

--- a/tests/IoUring.Tests/RingTest.cs
+++ b/tests/IoUring.Tests/RingTest.cs
@@ -179,6 +179,24 @@ namespace IoUring.Tests
             reader.Join();
             writer.Join();
         }
+
+        [Fact]
+        public void DetectOverSubmit()
+        {
+            var r = new Ring(8);
+
+            for (int i = 0; i < r.SubmissionQueueSize; i++)
+            {
+                r.PrepareNop();
+            }
+
+            Assert.Throws<SubmissionQueueFullException>(() =>
+            {
+                r.PrepareNop();
+            });
+            
+            Assert.False(r.TryPrepareNop());
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #24.

@tmds
Let me know if you find this approach to things more intuitive from a users perspective